### PR TITLE
♻️ ref: Decoupled ProductRepository for better layer isolation.

### DIFF
--- a/src/DeveloperStore.Sales/DeveloperStore.Sales.Api/Configuration/DependencyInjection.cs
+++ b/src/DeveloperStore.Sales/DeveloperStore.Sales.Api/Configuration/DependencyInjection.cs
@@ -19,10 +19,10 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddDependencyInjection(this IServiceCollection services)
     {
-        services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IMongoDbContext, MongoDbContext>();
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+
         services.AddScoped<IEventLogMongoDbRepository, EventLogMongoDbRepository>();
-        services.AddScoped<IProductRepository, ProductRepository>();
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<ICartRepository, CartRepository>();
         services.AddScoped<ICartProductRepository, CartProductRepository>();

--- a/src/DeveloperStore.Sales/DeveloperStore.Sales.Service/Services/ProductService.cs
+++ b/src/DeveloperStore.Sales/DeveloperStore.Sales.Service/Services/ProductService.cs
@@ -5,6 +5,7 @@ using DeveloperStore.Sales.Domain.Models;
 using DeveloperStore.Sales.Service.Extensions;
 using DeveloperStore.Sales.Service.Interfaces;
 using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Extensions;
+using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Interfaces;
 using DeveloperStore.Sales.Storage.UnitOfWork;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;

--- a/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/SQL/PostgreSQL/Repositories/ProductRepository.cs
+++ b/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/SQL/PostgreSQL/Repositories/ProductRepository.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DeveloperStore.Sales.Storage.SQL.PostgreSQL.Repositories;
 
-public class ProductRepository : BaseRepository<Product>, IProductRepository
+internal class ProductRepository : BaseRepository<Product>, IProductRepository
 {
     public ProductRepository(IPostgreSqlDbContext context) : base(context) { }
 

--- a/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/UnitOfWork/IUnitOfWork.cs
+++ b/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/UnitOfWork/IUnitOfWork.cs
@@ -1,10 +1,12 @@
 ﻿using DeveloperStore.Sales.Storage.NoSQL.MongoDb.Interfaces;
+using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Contexts;
 using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Interfaces;
 
 namespace DeveloperStore.Sales.Storage.UnitOfWork;
 
 public interface IUnitOfWork
 {
+    IPostgreSqlDbContext Context { get; }
     IProductRepository ProductRepository { get; }
     IUserRepository UserRepository { get; }
     ICartRepository CartRepository { get; }

--- a/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/UnitOfWork/UnitOfWork.cs
+++ b/src/DeveloperStore.Sales/DeveloperStore.Sales.Storage/UnitOfWork/UnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿using DeveloperStore.Sales.Storage.NoSQL.MongoDb.Interfaces;
 using DeveloperStore.Sales.Storage.NoSQL.MongoDb.Repositories;
+using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Contexts;
 using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Interfaces;
 using DeveloperStore.Sales.Storage.SQL.PostgreSQL.Repositories;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -25,6 +26,7 @@ public class UnitOfWork : IUnitOfWork
         _mongoDbContext = mongoDbContext ?? throw new ArgumentNullException(nameof(mongoDbContext));
     }
 
+    public IPostgreSqlDbContext Context =>_context;
     public IProductRepository ProductRepository => _productRepository ??= new ProductRepository(_context);
     public IUserRepository UserRepository => _userRepository ??= new UserRepository(_context);
     public ICartRepository CartRepository => _cartRepository ??= new CartRepository(_context);


### PR DESCRIPTION
- Refactored ProductRepository to ensure access is restricted to the Storage layer.
- Updated constructor to use IPostgreSqlDbContext instead of IUnitOfWork.
- Removed direct dependency of ProductService on IProductRepository, enforcing the use of UnitOfWork.
- Ensured compliance with separation of concerns and improved adherence to layered architecture principles.
- Adjusted DependencyInjection to avoid registering IProductRepository explicitly.
